### PR TITLE
Bugfix for object array outputting as null in JSON output

### DIFF
--- a/src/Services/StructuredDataService.php
+++ b/src/Services/StructuredDataService.php
@@ -95,6 +95,10 @@ class StructuredDataService
                     $result[$key] = $field['values'];
                 } elseif ($field['type'] === 'object' && isset($field['value'])) {
                     $result[$key] = $this->transformSchema($field['value']);
+                } elseif ($field['type'] === 'object_array' && isset($field['values'])) {
+                    foreach ($field['values'] as $value) {
+                        $result[$key][] =  $this->transformSchema($value);
+                    }
                 } elseif ($field['type'] === 'numeric' && isset($field['value'])) {
                     $result[$key] = (float) $field['value'];
                 } else {


### PR DESCRIPTION
When using object array the preview inside the control panel would show correctly but the output of the JSON in the head would show as null. My use case was for subOrganization and Department schema and this pull request change fixes the output.