### PR TITLE
Allow PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     },
     "require": {
-        "php": "^8.2|^8.3",
+        "php": "^8.2|^8.3|^8.4",
         "laravel/framework": "^11.0 | ^12.0",
         "statamic/cms": "^5.0"
     },


### PR DESCRIPTION
Widens the `php` constraint on `1.x` from `^8.2|^8.3` to `^8.2|^8.3|^8.4`. No code changes needed.

`1.x` already allows `laravel/framework: "^11.0 | ^12.0"`, and both Laravel 11 and 12 declare `"php": "^8.2"`, so the `php` ceiling is narrower than the framework range in the same file. The constraint looks like it simply predates PHP 8.4.

Verified on 8.4.23: all files in `src/` pass `php -l`, nullable parameters are already explicitly typed (so the 8.4 implicit-nullable deprecation does not apply), and the runtime dependency tree resolves cleanly.

Motivation: we run a Statamic 5 site on PHP 8.4 and would like to use the addon without forcing platform requirements. `2.x` requires Statamic 6, so `1.x` is the only line available to us.
